### PR TITLE
add fallback option for flickr portlet 

### DIFF
--- a/pleiades/portlet/flickr/browser.py
+++ b/pleiades/portlet/flickr/browser.py
@@ -24,7 +24,7 @@ PAGE_TMPL = "https://flickr.com/photos/%(owner)s/%(id)s/in/pool-1876758@N22"
 def _flickr_cache_key(method, self, pid):
     # Two hour RAM cache on API requests
     cache_time = time() // (2 * 60 * 60)
-    return '{}/{}/{}'.format(method.__name__, pid, cache_time)
+    return "{}/{}/{}".format(method.__name__, pid, cache_time)
 
 
 class FlickrResponseError(ValueError):
@@ -32,18 +32,17 @@ class FlickrResponseError(ValueError):
 
 
 class RelatedFlickrJson(BrowserView):
-
     """Makes two Flickr API calls and writes the number of related
     photos and URLs for the most viewed related photo from the Pleiades
     Places group to JSON like
 
     {"portrait": {
-      "page": 
-        "http://flickr.com/photos/27621672@N04/3734425631/in/pool-1876758@N22", 
-       "img": "http://farm3.staticflickr.com/2474/3734425631_b15979f2cd_m.jpg", 
-       "title": "Pont d'Ambroix by sgillies" }, 
+      "page":
+        "http://flickr.com/photos/27621672@N04/3734425631/in/pool-1876758@N22",
+       "img": "http://farm3.staticflickr.com/2474/3734425631_b15979f2cd_m.jpg",
+       "title": "Pont d'Ambroix by sgillies" },
      "related": {
-       "url": ["http://www.flickr.com/photos/tags/pleiades:*=149492/"], 
+       "url": ["http://www.flickr.com/photos/tags/pleiades:*=149492/"],
        "total": 2 }}
 
     for use in the Flickr Photos portlet on every Pleiades place page.
@@ -57,24 +56,30 @@ class RelatedFlickrJson(BrowserView):
             api_key=FLICKR_API_KEY,
             machine_tags="pleiades:*=%s" % pid,
             format="json",
-            nojsoncallback=1)
+            nojsoncallback=1,
+        )
 
         start = time()
         try:
-            resp = requests.get(FLICKR_API_ENDPOINT, params=q,
-                                timeout=(3.05, 5))
+            resp = requests.get(FLICKR_API_ENDPOINT, params=q, timeout=(3.05, 5))
         except requests.exceptions.RequestException:
-            log.exception('Error making Flickr request for {}'.format(pid))
+            log.exception("Error making Flickr request for {}".format(pid))
             raise FlickrResponseError(500)
 
-        log.info('Flickr related request for pid {} took {} seconds'.format(
-            pid, time() - start))
+        log.info(
+            "Flickr related request for pid {} took {} seconds".format(
+                pid, time() - start
+            )
+        )
 
         if resp.status_code == 200:
             return resp.json()
 
-        log.warn('Bad related Flickr data for pid {}, response code {}'.format(
-            pid, resp.status_code))
+        log.warn(
+            "Bad related Flickr data for pid {}, response code {}".format(
+                pid, resp.status_code
+            )
+        )
         raise FlickrResponseError(resp.status_code)
 
     @ram.cache(_flickr_cache_key)
@@ -86,28 +91,39 @@ class RelatedFlickrJson(BrowserView):
             group_id=PLEIADES_PLACES_ID,
             extras="views",
             format="json",
-            nojsoncallback=1)
+            nojsoncallback=1,
+        )
 
-        if pid != "*":
-            q['tags'] = "pleiades:depicts=" + pid
+        # try for a depiction of the place in the group pool
+        # if there is not one, try for something found there
+        for mtag in ["pleiades:depicts=" + pid, "pleiades:findspot=" + pid]:
+            if pid != "*":
+                q["tags"] = mtag
 
-        start = time()
-        try:
-            resp = requests.get(FLICKR_API_ENDPOINT, params=q,
-                                timeout=(3.05, 5))
-        except requests.exceptions.RequestException:
-            log.exception('Error making Flickr pool request for {}'.format(
-                pid))
-            raise FlickrResponseError(500)
+            start = time()
+            try:
+                resp = requests.get(FLICKR_API_ENDPOINT, params=q, timeout=(3.05, 5))
+            except requests.exceptions.RequestException:
+                log.exception("Error making Flickr pool request for {}".format(pid))
+                raise FlickrResponseError(500)
 
-        log.info('Flickr pool request for pid {} took {} seconds'.format(
-            pid, time() - start))
+            log.info(
+                "Flickr pool request for pid {} took {} seconds".format(
+                    pid, time() - start
+                )
+            )
 
+            if resp.status_code == 200:
+                if len(resp.json()["photos"]["photo"]) > 0:
+                    return resp.json()
+            else:
+                log.warn(
+                    "Bad Flickr pool data for pid {}, response code {}".format(
+                        pid, resp.status_code
+                    )
+                )
         if resp.status_code == 200:
             return resp.json()
-
-        log.warn('Bad Flickr pool data for pid {}, response code {}'.format(
-            pid, resp.status_code))
         raise FlickrResponseError(resp.status_code)
 
     def __call__(self, **kw):
@@ -129,11 +145,11 @@ class RelatedFlickrJson(BrowserView):
 
         if related:
             total = 0
-            photos = related.get('photos')
+            photos = related.get("photos")
             if photos:
-                total = int(photos['total'])
+                total = int(photos["total"])
 
-            data['related'] = dict(total=total, url=FLICKR_TAGS_BASE + tag)
+            data["related"] = dict(total=total, url=FLICKR_TAGS_BASE + tag)
 
         try:
             pool = self._get_pool_photos(pid)
@@ -143,24 +159,25 @@ class RelatedFlickrJson(BrowserView):
 
         if pool:
             total = 0
-            photos = pool.get('photos')
+            photos = pool.get("photos")
             if photos:
-                total = int(photos['total'])
+                total = int(photos["total"])
             if total < 1:
-                data['portrait'] = None
+                data["portrait"] = None
             else:
                 # Sort found photos by number of views, descending
                 most_viewed = sorted(
-                    photos['photo'], key=lambda p: p['views'], reverse=True )
+                    photos["photo"], key=lambda p: p["views"], reverse=True
+                )
                 if pid == "*":
                     photo = choice(most_viewed)
                 else:
                     photo = most_viewed[0]
 
-                title = "%s by %s." % (
-                    photo['title'].rstrip(" ."), photo['ownername'] )
-                data['portrait'] = dict(
-                    title=title, img=IMG_TMPL % photo, page=PAGE_TMPL % photo )
+                title = "%s by %s." % (photo["title"].rstrip(" ."), photo["ownername"])
+                data["portrait"] = dict(
+                    title=title, img=IMG_TMPL % photo, page=PAGE_TMPL % photo
+                )
 
-        self.request.response.setHeader('Content-Type', 'application/json')
+        self.request.response.setHeader("Content-Type", "application/json")
         return simplejson.dumps(data)


### PR DESCRIPTION
so that if a depiction (machine tag `pleiades:depicts=` is not found in the group, something found there (`pleiades:findspot=`) will be posted if available.

`pid="422984"` is a good test example; it should return this photo: https://www.flickr.com/photos/chappspix/53472596591/in/pool-pleiades-places/, which has a `pleiades:findspot` machine tag (there is no `pleiades:depicts` machine-tagged photo in the group for this place).
